### PR TITLE
Return the function object rather than a plain object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,30 @@
-module.exports = function AddAssetsWebpackPlugin (options) {
-  return {
-    apply: (compiler) => {
-      const assetsToAdd = Array.isArray(options)
-        ? options
-        : [options]
-
-      compiler.plugin('emit', function(compilation, callback) {
-        assetsToAdd
-          .forEach(assetToAdd => {
-            const hasFilePath = assetToAdd.filePath != null
-            const hasContent = assetToAdd.content != null
-            if (!hasFilePath || !hasContent) {
-              const optionNeeded = !hasContent
-                ? 'content'
-                : 'filePath'
-              const message = `AddAssetsWebpackPlugin Error: The '${optionNeeded}' option must be passed`
-              return console.error("\n\n\x1b[41m", message, "\x1b[0m", "\n")
-            }
-
-            compilation.assets[assetToAdd.filePath] = {
-              source: () => new Buffer(assetToAdd.content),
-              size: () => Buffer.byteLength(assetToAdd.content),
-            }
-          })
-
-        callback()
-      })
-    }
-  }
+function AddAssetsWebpackPlugin(options) {
+  this.options = options;
 }
+
+AddAssetsWebpackPlugin.prototype.apply = function(compiler) {
+  const assetsToAdd = Array.isArray(this.options)
+    ? this.options
+    : [this.options];
+
+  compiler.plugin("emit", function(compilation, callback) {
+    assetsToAdd.forEach(assetToAdd => {
+      const hasFilePath = assetToAdd.filePath != null;
+      const hasContent = assetToAdd.content != null;
+      if (!hasFilePath || !hasContent) {
+        const optionNeeded = !hasContent ? "content" : "filePath";
+        const message = `AddAssetsWebpackPlugin Error: The '${optionNeeded}' option must be passed`;
+        return console.error("\n\n\x1b[41m", message, "\x1b[0m", "\n");
+      }
+
+      compilation.assets[assetToAdd.filePath] = {
+        source: () => new Buffer(assetToAdd.content),
+        size: () => Buffer.byteLength(assetToAdd.content)
+      };
+    });
+
+    callback();
+  });
+};
+
+module.exports = AddAssetsWebpackPlugin;


### PR DESCRIPTION
This makes the plugin work like other Webpack plugins, in that it returns a function object with an `apply` member rather than a plain object. It's a bit weird, but it lets us test it in the same way as the third-party Webpack plugins we're using in geo_me-webpack.